### PR TITLE
Refactor and clean-up NFC

### DIFF
--- a/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
+++ b/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
@@ -26,6 +26,7 @@ class ScalarEvolution;
 
 struct FunctionStackSummary;
 
+// Stack analysis interface provided to other analysis consumers
 class StackSafetyInfo {
   using Callback = std::function<ScalarEvolution *(const Function &F)>;
   Callback GetSECallback;
@@ -35,6 +36,7 @@ public:
   void run(Function &F, FunctionStackSummary &FS) const;
 };
 
+// Analysis pass for the legacy pass manager
 class StackSafetyWrapperPass : public ModulePass {
   std::unique_ptr<StackSafetyInfo> SSI;
 
@@ -57,6 +59,17 @@ public:
 // object for the module, to be written to bitcode or LLVM assembly.
 //
 ModulePass *createStackSafetyWrapperPass();
+
+// Analysis pass for the new pass manager
+class StackSafetyAnalysis : public AnalysisInfoMixin<StackSafetyAnalysis> {
+  static AnalysisKey Key;
+  friend AnalysisInfoMixin<StackSafetyAnalysis>;
+
+public:
+  using Result = StackSafetyInfo;
+
+  Result run(Module &M, ModuleAnalysisManager &AM);
+};
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
+++ b/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
@@ -22,13 +22,30 @@ namespace llvm {
 
 class Function;
 class Module;
-class StackSafety;
+class ScalarEvolution;
+
+struct FunctionStackSummary;
+
+class StackSafetyInfo {
+  using Callback = std::function<ScalarEvolution *(const Function &F)>;
+  Callback GetSECallback;
+
+public:
+  StackSafetyInfo(Callback GetSECallback) : GetSECallback(GetSECallback) {}
+  void run(Function &F, FunctionStackSummary &FS) const;
+};
 
 class StackSafetyWrapperPass : public ModulePass {
+  std::unique_ptr<StackSafetyInfo> SSI;
+
 public:
   static char ID;
 
   StackSafetyWrapperPass();
+
+  StackSafetyInfo &getSSI() { return *SSI; }
+  bool doInitialization(Module &M);
+  bool doFinalization(Module &M);
 
   bool runOnModule(Module &M) override;
   void getAnalysisUsage(AnalysisUsage &AU) const override;

--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -675,7 +675,6 @@ char StackSafetyWrapperPass::ID = 0;
 
 INITIALIZE_PASS_BEGIN(StackSafetyWrapperPass, DEBUG_TYPE,
                       "Stack safety analysis pass", false, false)
-INITIALIZE_PASS_DEPENDENCY(TargetPassConfig)
 INITIALIZE_PASS_END(StackSafetyWrapperPass, DEBUG_TYPE,
                     "Stack safety analysis pass", false, false)
 

--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -691,6 +691,15 @@ bool StackSafetyWrapperPass::doFinalization(Module &M) {
 
 char StackSafetyWrapperPass::ID = 0;
 
+AnalysisKey StackSafetyAnalysis::Key;
+
+StackSafetyInfo StackSafetyAnalysis::run(Module &M, ModuleAnalysisManager &AM) {
+  auto &FAM = AM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
+  return StackSafetyInfo([&FAM](const Function &F) {
+    return &FAM.getResult<ScalarEvolutionAnalysis>(*const_cast<Function*>(&F));
+  });
+}
+
 } // namespace llvm
 
 INITIALIZE_PASS_BEGIN(StackSafetyWrapperPass, DEBUG_TYPE,

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionAliasAnalysis.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
+#include "llvm/Analysis/StackSafetyAnalysis.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/TypeBasedAliasAnalysis.h"

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -24,6 +24,7 @@ MODULE_ANALYSIS("lcg", LazyCallGraphAnalysis())
 MODULE_ANALYSIS("module-summary", ModuleSummaryIndexAnalysis())
 MODULE_ANALYSIS("no-op-module", NoOpModuleAnalysis())
 MODULE_ANALYSIS("profile-summary", ProfileSummaryAnalysis())
+MODULE_ANALYSIS("stack-safety", StackSafetyAnalysis())
 MODULE_ANALYSIS("targetlibinfo", TargetLibraryAnalysis())
 MODULE_ANALYSIS("verify", VerifierAnalysis())
 


### PR DESCRIPTION
Refactor out a minimal StackSafetyInfo class that can be exposed to ModuleSummaryAnalysis. This means moving the *Summary structs to the llvm namespace so I needed to rename FunctionSummary to something else.