### PR TITLE
Add ThinLTO/fix non-local analysis stack safety alias support

### DIFF
--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -238,7 +238,8 @@ SSFunctionSummary::SSFunctionSummary(FunctionSummary &FS) {
 }
 
 SSFunctionSummary::SSFunctionSummary(GlobalAlias &A) {
-  assert(isa<Function>(A.getAliasee()));
+  Function *DestFn = dyn_cast<Function>(A.getAliasee()->stripPointerCasts());
+  assert(DestFn);
 
   this->GV = &A;
   this->GVS = nullptr;
@@ -246,8 +247,6 @@ SSFunctionSummary::SSFunctionSummary(GlobalAlias &A) {
   this->Interposable = A.isInterposable();
 
   // 'Forward' all parameters to this alias to the aliasee
-  Function *DestFn = cast<Function>(A.getAliasee());
-
   for (unsigned ArgNo = 0; ArgNo < DestFn->arg_size(); ArgNo++) {
     this->Params.emplace_back();
     SSUseSummary &US = this->Params.back().Summary;

--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -928,6 +928,9 @@ bool StackSafetyGlobalAnalysis::runOnModule(Module &M) {
             break;
         }
       }
+
+      assert(GVS->isLive() &&
+             "Promoted/internalized/imported function must be live");
     }
 
     assert(GVS && "GlobalValueSummary for function not found");

--- a/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa-alias.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa-alias.ll
@@ -2,9 +2,14 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
 @InterposableAliasWrite1 = linkonce dso_local alias void(i8*), void(i8*)* @Write1
+
 @PreemptableAliasWrite1 = dso_preemptable alias void(i8*), void(i8*)* @Write1
+@AliasToPreemptableAliasWrite1 = dso_local alias void(i8*), void(i8*)* @PreemptableAliasWrite1
+
 @AliasWrite1 = dso_local alias void(i8*), void(i8*)* @Write1
+
 @BitcastAliasWrite1 = dso_local alias void(i32*), bitcast (void(i8*)* @Write1 to void(i32*)*)
+@AliasToBitcastAliasWrite1 = dso_local alias void(i8*), bitcast (void(i32*)* @BitcastAliasWrite1 to void(i8*)*)
 
 define dso_local void @Write1(i8* %p) {
 entry:

--- a/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa-alias.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa-alias.ll
@@ -1,0 +1,12 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@InterposableAliasWrite1 = linkonce dso_local alias void(i8*), void(i8*)* @Write1
+@PreemptableAliasWrite1 = dso_preemptable alias void(i8*), void(i8*)* @Write1
+@AliasWrite1 = dso_local alias void(i8*), void(i8*)* @Write1
+
+define dso_local void @Write1(i8* %p) {
+entry:
+  store i8 0, i8* %p, align 1
+  ret void
+}

--- a/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa-alias.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa-alias.ll
@@ -4,6 +4,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @InterposableAliasWrite1 = linkonce dso_local alias void(i8*), void(i8*)* @Write1
 @PreemptableAliasWrite1 = dso_preemptable alias void(i8*), void(i8*)* @Write1
 @AliasWrite1 = dso_local alias void(i8*), void(i8*)* @Write1
+@BitcastAliasWrite1 = dso_local alias void(i32*), bitcast (void(i8*)* @Write1 to void(i32*)*)
 
 define dso_local void @Write1(i8* %p) {
 entry:

--- a/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/Inputs/ipa.ll
@@ -1,8 +1,6 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-@AliasWrite1 = alias void(i8*), void(i8*)* @Write1
-
 define dso_local void @Write1(i8* %p) {
 entry:
   store i8 0, i8* %p, align 1

--- a/llvm/test/Analysis/StackSafetyAnalysis/ipa-alias.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/ipa-alias.ll
@@ -1,0 +1,61 @@
+; Test IPA over a single combined file
+; RUN: llvm-as %s -o %t0.bc
+; RUN: llvm-as %S/Inputs/ipa-alias.ll -o %t1.bc
+; RUN: llvm-link %t0.bc %t1.bc -o %t.combined.bc
+; RUN: opt -S -stack-safety %t.combined.bc | FileCheck --check-prefixes=CHECK,WITHOUTLTO %s
+
+; Do an end-to-test using the new LTO API
+; RUN: opt -module-summary %s -o %t.summ0.bc
+; RUN: opt -module-summary %S/Inputs/ipa-alias.ll -o %t.summ1.bc
+; RUN: llvm-lto2 run %t.summ0.bc %t.summ1.bc -o %t.lto -save-temps -thinlto-threads 1 -O0 \
+; RUN:  -r %t.summ0.bc,PreemptableAliasWrite1, \
+; RUN:  -r %t.summ0.bc,InterposableAliasWrite1, \
+; RUN:  -r %t.summ0.bc,AliasWrite1, \
+; RUN:  -r %t.summ0.bc,PreemptableAliasCall,px \
+; RUN:  -r %t.summ0.bc,InterposableAliasCall,px \
+; RUN:  -r %t.summ0.bc,AliasCall,px \
+; RUN:  -r %t.summ1.bc,PreemptableAliasWrite1,px \
+; RUN:  -r %t.summ1.bc,InterposableAliasWrite1,px \
+; RUN:  -r %t.summ1.bc,AliasWrite1,px \
+; RUN:  -r %t.summ1.bc,Write1,px
+
+; RUN: llvm-dis %t.lto.1.4.opt.bc -o - | FileCheck --check-prefixes=CHECK,THINLTO %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @PreemptableAliasWrite1(i8* %p)
+declare void @InterposableAliasWrite1(i8* %p)
+declare void @AliasWrite1(i8* %p)
+
+; Call to dso_preemptable alias to a dso_local aliasee
+define void @PreemptableAliasCall() {
+; CHECK-LABEL: define void @PreemptableAliasCall
+entry:
+  %x = alloca i8
+; CHECK: %x = alloca i8{{$}}
+  call void @PreemptableAliasWrite1(i8* %x)
+  ret void
+}
+
+; Call to an interposable alias to a non-interposable aliasee
+define void @InterposableAliasCall() {
+; CHECK-LABEL: define void @InterposableAliasCall
+entry:
+  %x = alloca i8
+; ThinLTO can resolve the prevailing implementation for interposable definitions.
+; WITHOUTLTO: %x = alloca i8{{$}}
+; THINLTO: %x = alloca i8, !stack-safe
+  call void @InterposableAliasWrite1(i8* %x)
+  ret void
+}
+
+; Call to a dso_local/non-inteprosable alias/aliasee
+define void @AliasCall() {
+; CHECK-LABEL: define void @AliasCall
+entry:
+  %x = alloca i8
+; CHECK: %x = alloca i8, !stack-safe
+  call void @AliasWrite1(i8* %x)
+  ret void
+}

--- a/llvm/test/Analysis/StackSafetyAnalysis/ipa-alias.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/ipa-alias.ll
@@ -9,17 +9,21 @@
 ; RUN: opt -module-summary %S/Inputs/ipa-alias.ll -o %t.summ1.bc
 ; RUN: llvm-lto2 run %t.summ0.bc %t.summ1.bc -o %t.lto -save-temps -thinlto-threads 1 -O0 \
 ; RUN:  -r %t.summ0.bc,PreemptableAliasWrite1, \
+; RUN:  -r %t.summ0.bc,AliasToPreemptableAliasWrite1, \
 ; RUN:  -r %t.summ0.bc,InterposableAliasWrite1, \
 ; RUN:  -r %t.summ0.bc,AliasWrite1, \
 ; RUN:  -r %t.summ0.bc,BitcastAliasWrite1, \
+; RUN:  -r %t.summ0.bc,AliasToBitcastAliasWrite1, \
 ; RUN:  -r %t.summ0.bc,PreemptableAliasCall,px \
 ; RUN:  -r %t.summ0.bc,InterposableAliasCall,px \
 ; RUN:  -r %t.summ0.bc,AliasCall,px \
 ; RUN:  -r %t.summ0.bc,BitcastAliasCall,px \
 ; RUN:  -r %t.summ1.bc,PreemptableAliasWrite1,px \
+; RUN:  -r %t.summ1.bc,AliasToPreemptableAliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,InterposableAliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,AliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,BitcastAliasWrite1,px \
+; RUN:  -r %t.summ1.bc,AliasToBitcastAliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,Write1,px
 
 ; RUN: llvm-dis %t.lto.1.4.opt.bc -o - | FileCheck --check-prefixes=CHECK,THINLTO %s
@@ -28,17 +32,29 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
 declare void @PreemptableAliasWrite1(i8* %p)
+declare void @AliasToPreemptableAliasWrite1(i8* %p)
+
 declare void @InterposableAliasWrite1(i8* %p)
+; Aliases to interposable aliases are not allowed
+
 declare void @AliasWrite1(i8* %p)
+
 declare void @BitcastAliasWrite1(i32* %p)
+declare void @AliasToBitcastAliasWrite1(i8* %p)
 
 ; Call to dso_preemptable alias to a dso_local aliasee
 define void @PreemptableAliasCall() {
 ; CHECK-LABEL: define void @PreemptableAliasCall
 entry:
-  %x = alloca i8
-; CHECK: %x = alloca i8{{$}}
-  call void @PreemptableAliasWrite1(i8* %x)
+  %x1 = alloca i8
+; CHECK: %x1 = alloca i8{{$}}
+  call void @PreemptableAliasWrite1(i8* %x1)
+
+  %x2 = alloca i8
+; TODO: This should work for ThinLTO but doesn't due to https://bugs.llvm.org/show_bug.cgi?id=37884
+; WITHOUTLTO: %x2 = alloca i8{{$}}
+; THINLTO: %x2 = alloca i8, !stack-safe
+  call void @AliasToPreemptableAliasWrite1(i8* %x2)
   ret void
 }
 
@@ -68,8 +84,12 @@ entry:
 define void @BitcastAliasCall() {
 ; CHECK-LABEL: define void @BitcastAliasCall
 entry:
-  %x = alloca i32
-; CHECK: %x = alloca i32, !stack-safe
-  call void @BitcastAliasWrite1(i32* %x)
+  %x1 = alloca i32
+; CHECK: %x1 = alloca i32, !stack-safe
+  call void @BitcastAliasWrite1(i32* %x1)
+
+  %x2 = alloca i8
+; CHECK: %x2 = alloca i8, !stack-safe
+  call void @AliasToBitcastAliasWrite1(i8* %x2)
   ret void
 }

--- a/llvm/test/Analysis/StackSafetyAnalysis/ipa-alias.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/ipa-alias.ll
@@ -11,12 +11,15 @@
 ; RUN:  -r %t.summ0.bc,PreemptableAliasWrite1, \
 ; RUN:  -r %t.summ0.bc,InterposableAliasWrite1, \
 ; RUN:  -r %t.summ0.bc,AliasWrite1, \
+; RUN:  -r %t.summ0.bc,BitcastAliasWrite1, \
 ; RUN:  -r %t.summ0.bc,PreemptableAliasCall,px \
 ; RUN:  -r %t.summ0.bc,InterposableAliasCall,px \
 ; RUN:  -r %t.summ0.bc,AliasCall,px \
+; RUN:  -r %t.summ0.bc,BitcastAliasCall,px \
 ; RUN:  -r %t.summ1.bc,PreemptableAliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,InterposableAliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,AliasWrite1,px \
+; RUN:  -r %t.summ1.bc,BitcastAliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,Write1,px
 
 ; RUN: llvm-dis %t.lto.1.4.opt.bc -o - | FileCheck --check-prefixes=CHECK,THINLTO %s
@@ -27,6 +30,7 @@ target triple = "x86_64-unknown-linux-gnu"
 declare void @PreemptableAliasWrite1(i8* %p)
 declare void @InterposableAliasWrite1(i8* %p)
 declare void @AliasWrite1(i8* %p)
+declare void @BitcastAliasWrite1(i32* %p)
 
 ; Call to dso_preemptable alias to a dso_local aliasee
 define void @PreemptableAliasCall() {
@@ -57,5 +61,15 @@ entry:
   %x = alloca i8
 ; CHECK: %x = alloca i8, !stack-safe
   call void @AliasWrite1(i8* %x)
+  ret void
+}
+
+; Call to a bitcasted dso_local/non-inteprosable alias/aliasee
+define void @BitcastAliasCall() {
+; CHECK-LABEL: define void @BitcastAliasCall
+entry:
+  %x = alloca i32
+; CHECK: %x = alloca i32, !stack-safe
+  call void @BitcastAliasWrite1(i32* %x)
   ret void
 }

--- a/llvm/test/Analysis/StackSafetyAnalysis/ipa.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/ipa.ll
@@ -16,7 +16,6 @@
 ; RUN:  -r %t.summ0.bc,ExternalCall, \
 ; RUN:  -r %t.summ0.bc,PreemptableWrite1, \
 ; RUN:  -r %t.summ0.bc,InterposableWrite1, \
-; RUN:  -r %t.summ0.bc,AliasWrite1, \
 ; RUN:  -r %t.summ0.bc,ReturnDependent, \
 ; RUN:  -r %t.summ0.bc,Rec2, \
 ; RUN:  -r %t.summ0.bc,RecursiveNoOffset, \
@@ -29,7 +28,6 @@
 ; RUN:  -r %t.summ0.bc,f6,px \
 ; RUN:  -r %t.summ0.bc,PreemptableCall,px \
 ; RUN:  -r %t.summ0.bc,InterposableCall,px \
-; RUN:  -r %t.summ0.bc,AliasCall,px \
 ; RUN:  -r %t.summ0.bc,PrivateCall,px \
 ; RUN:  -r %t.summ0.bc,f7,px \
 ; RUN:  -r %t.summ0.bc,f8left,px \
@@ -49,7 +47,6 @@
 ; RUN:  -r %t.summ1.bc,ExternalCall,px \
 ; RUN:  -r %t.summ1.bc,PreemptableWrite1,px \
 ; RUN:  -r %t.summ1.bc,InterposableWrite1,px \
-; RUN:  -r %t.summ1.bc,AliasWrite1,px \
 ; RUN:  -r %t.summ1.bc,ReturnDependent,px \
 ; RUN:  -r %t.summ1.bc,Rec0,px \
 ; RUN:  -r %t.summ1.bc,Rec1,px \
@@ -69,7 +66,6 @@ declare void @Write8(i8* %p)
 declare dso_local void @ExternalCall(i8* %p)
 declare void @PreemptableWrite1(i8* %p)
 declare void @InterposableWrite1(i8* %p)
-declare void @AliasWrite1(i8* %p)
 declare i8* @ReturnDependent(i8* %p)
 declare void @Rec2(i8* %p)
 declare void @RecursiveNoOffset(i32* %p, i32 %size, i32* %acc)
@@ -170,19 +166,6 @@ entry:
 ; WITHOUTLTO: %x = alloca i32, align 4{{$}}
 ; THINLTO: %x = alloca i32, align 4, !stack-safe
   call void @InterposableWrite1(i8* %x1)
-  ret void
-}
-
-; Call to an alias
-define void @AliasCall() {
-; CHECK-LABEL: define void @AliasCall
-entry:
-  %x = alloca i32, align 4
-  %x1 = bitcast i32* %x to i8*
-; TODO: We don't currently look-through aliases with ThinLTO so %x is not marked !stack-safe
-; WITHOUTLTO: %x = alloca i32, align 4, !stack-safe
-; THINLTO: %x = alloca i32, align 4{{$}}
-  call void @AliasWrite1(i8* %x1)
   ret void
 }
 


### PR DESCRIPTION
Implementing alias support with ThinLTO increased the number of allocas (by count) marked stack-safe from 45% to 59% for chromium. 